### PR TITLE
Add wrapper for sockrus initialization

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -1,0 +1,96 @@
+package sockrus
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	logrus_logstash "github.com/bshuster-repo/logrus-logstash-hook"
+)
+
+// Hook represents a connection to a socket
+type Hook struct {
+	formatter logrus_logstash.LogstashFormatter
+	conn      net.Conn
+	protocol  string
+	address   string
+	mute      bool
+}
+
+// NewHook establish a socket connection.
+// Protocols allowed are: "udp", "tcp", "unix" (corresponds to SOCK_STREAM),
+// "unixdomain" (corresponds to SOCK_DGRAM) or "unixpacket" (corresponds to SOCK_SEQPACKET).
+//
+// For TCP and UDP, address must have the form `host:port`.
+//
+// For Unix networks, the address must be a file system path.
+func NewHook(protocol, address string) (*Hook, error) {
+	logstashFormatter := logrus_logstash.LogstashFormatter{
+		TimestampFormat: time.RFC3339Nano,
+	}
+	return &Hook{
+		conn:      nil,
+		protocol:  protocol,
+		address:   address,
+		formatter: logstashFormatter,
+		mute:      false,
+	}, nil
+}
+
+// Fire send log to the defined socket
+func (h *Hook) Fire(entry *logrus.Entry) error {
+	var err error
+	if h.conn == nil {
+		err = h.dialSock()
+		if err != nil && h.mute == false {
+			h.mute = true
+			retErr := fmt.Errorf("Failed to dial. All further errors will be muted: %v", err)
+			return retErr
+		} else if err != nil && h.mute == true {
+			return nil
+		}
+	}
+	dataBytes, err := h.formatter.Format(entry)
+	if err != nil {
+		return err
+	}
+	if _, err = h.conn.Write(dataBytes); err != nil {
+		_ = h.closeSock() // #nosec
+		if h.mute == false {
+			h.mute = true
+			retErr := fmt.Errorf("Failed to write data. All further errors will be muted: %v", err)
+			return retErr
+		} else {
+			return nil
+		}
+	}
+	return nil
+}
+
+// Levels return an array of handled logging levels
+func (h *Hook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// closeSock tries to close connection to Unix socket
+func (h *Hook) closeSock() error {
+	if h.conn == nil {
+		return nil
+	}
+	err := h.conn.Close()
+	h.conn = nil
+	return err
+}
+
+// dialSock tries to connect to Unix socket
+func (h *Hook) dialSock() error {
+	conn, err := net.Dial(h.protocol, h.address)
+	if err != nil {
+		h.conn = nil
+		return err
+	}
+	h.conn = conn
+	h.mute = false
+	return nil
+}

--- a/vendor/github.com/ShowMax/go-fqdn/LICENSE
+++ b/vendor/github.com/ShowMax/go-fqdn/LICENSE
@@ -1,0 +1,13 @@
+Copyright since 2015 Showmax s.r.o.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/ShowMax/go-fqdn/README.md
+++ b/vendor/github.com/ShowMax/go-fqdn/README.md
@@ -1,0 +1,26 @@
+# go-fqdn
+Simple wrapper around `net` and `os` golang standard libraries providing Fully Qualified Domain Name of the machine.
+
+## Usage
+Get the library...
+```
+$ go get github.com/ShowMax/go-fqdn
+```
+...and write some code.
+```
+package main
+
+import (
+	"fmt"
+	"github.com/ShowMax/go-fqdn"
+)
+
+func main() {
+	fmt.Println(fqdn.Get())
+}
+```
+
+`fqdn.Get()` returns:
+- machine's FQDN if found.
+- hostname if FQDN is not found.
+- return "unknown" if nothing is found.

--- a/vendor/github.com/ShowMax/go-fqdn/fqdn.go
+++ b/vendor/github.com/ShowMax/go-fqdn/fqdn.go
@@ -1,0 +1,37 @@
+package fqdn
+
+import (
+	"net"
+	"os"
+	"strings"
+)
+
+// Get Fully Qualified Domain Name
+// returns "unknown" or hostanme in case of error
+func Get() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+
+	addrs, err := net.LookupIP(hostname)
+	if err != nil {
+		return hostname
+	}
+
+	for _, addr := range addrs {
+		if ipv4 := addr.To4(); ipv4 != nil {
+			ip, err := ipv4.MarshalText()
+			if err != nil {
+				return hostname
+			}
+			hosts, err := net.LookupAddr(string(ip))
+			if err != nil || len(hosts) == 0 {
+				return hostname
+			}
+			fqdn := hosts[0]
+			return strings.TrimSuffix(fqdn, ".") // return fqdn without trailing dot
+		}
+	}
+	return hostname
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,12 @@
 	"ignore": "test",
 	"package": [
 		{
+			"checksumSHA1": "Cp8sJVMPvud4pUlxAZmnXQnnFTk=",
+			"path": "github.com/ShowMax/go-fqdn",
+			"revision": "2501cdd51ef4c60dd727c58b2199e1a09466b10f",
+			"revisionTime": "2016-09-09T08:34:04Z"
+		},
+		{
 			"checksumSHA1": "+fR/AtnnQXyyT36gzQgkpNb1cA4=",
 			"path": "github.com/Sirupsen/logrus",
 			"revision": "3ec0642a7fb6488f65b06f9040adc67e3990296a",


### PR DESCRIPTION
First of all, sockrus hook has been moved into file `hook.go`. Second, commit
adds a wrapper for sockrus initialization, resp. to initialize logrus with
sockrus hook. This wrapper returns new logrus instance and ready-to-use
logrus.Entry with common pre-configured fields.
